### PR TITLE
Claude/fix starship ssh columns 011 c ur vhwfs vgg y uhbs32 x9e

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -1,2 +1,6 @@
 background = 000000
 
+# SSH shell integration: automatically handle TERM for SSH sessions
+# ssh-env: Sets TERM=xterm-256color for SSH to avoid terminfo issues
+# ssh-terminfo: Installs ghostty terminfo on remote hosts
+shell-integration-features = ssh-env,ssh-terminfo

--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -9,10 +9,26 @@ $directory\
 [ ](fg:peach)\
 $character"""
 
-# Disable right prompt to fix SSH column width issues
-# Powerline separators (U+E0B0, U+E0B4, U+E0B6) have ambiguous East Asian Width
-# which causes cursor positioning problems in SSH sessions
-right_format = ""
+right_format = """
+[ ](yellow)\
+$git_branch\
+$git_status\
+[ ](fg:yellow bg:green)\
+$c\
+$rust\
+$golang\
+$nodejs\
+$php\
+$java\
+$kotlin\
+$haskell\
+$python\
+[ ](fg:green bg:sapphire)\
+$conda\
+[](fg:sapphire bg:lavender)\
+$time\
+[](fg:lavender)\
+$cmd_duration"""
 
 palette = 'adventure_time'
 

--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -9,26 +9,10 @@ $directory\
 [ ](fg:peach)\
 $character"""
 
-right_format = """
-[ ](yellow)\
-$git_branch\
-$git_status\
-[ ](fg:yellow bg:green)\
-$c\
-$rust\
-$golang\
-$nodejs\
-$php\
-$java\
-$kotlin\
-$haskell\
-$python\
-[ ](fg:green bg:sapphire)\
-$conda\
-[](fg:sapphire bg:lavender)\
-$time\
-[](fg:lavender)\
-$cmd_duration"""
+# Disable right prompt to fix SSH column width issues
+# Powerline separators (U+E0B0, U+E0B4, U+E0B6) have ambiguous East Asian Width
+# which causes cursor positioning problems in SSH sessions
+right_format = ""
 
 palette = 'adventure_time'
 

--- a/.dotfiles/shell/zshrc.base
+++ b/.dotfiles/shell/zshrc.base
@@ -6,6 +6,18 @@ HISTFILE="$HOME/.zsh_history"
 HISTSIZE=10000
 SAVEHIST=10000
 
+# Set UTF-8 locale to properly handle Unicode characters (especially powerline glyphs)
+# This fixes cursor positioning issues with ambiguous-width characters in SSH sessions
+if [[ -z "$LANG" ]] || [[ "$LANG" == "POSIX" ]] || [[ "$LANG" == "C" ]]; then
+  if locale -a 2>/dev/null | grep -qi "en_US.utf8\|en_US.UTF-8"; then
+    export LANG="en_US.UTF-8"
+    export LC_ALL="en_US.UTF-8"
+  elif locale -a 2>/dev/null | grep -qi "C.utf8\|C.UTF-8"; then
+    export LANG="C.UTF-8"
+    export LC_ALL="C.UTF-8"
+  fi
+fi
+
 if command -v nvim >/dev/null 2>&1; then
   export EDITOR="nvim"
 elif command -v vim >/dev/null 2>&1; then

--- a/.dotfiles/shell/zshrc.base
+++ b/.dotfiles/shell/zshrc.base
@@ -8,21 +8,24 @@ SAVEHIST=10000
 
 # Set UTF-8 locale to properly handle Unicode characters (especially powerline glyphs)
 # This fixes cursor positioning issues with ambiguous-width characters in SSH sessions
-if [[ -z "$LANG" ]] || [[ "$LANG" == "POSIX" ]] || [[ "$LANG" == "C" ]]; then
-  # Capture the actual locale name that exists on the system
-  local utf8_locale=$(locale -a 2>/dev/null | grep -i "^en_US\.utf" | head -1)
-  if [[ -n "$utf8_locale" ]]; then
-    export LANG="$utf8_locale"
-    export LC_ALL="$utf8_locale"
-  else
-    # Fallback to C.UTF-8 or C.utf8
-    local c_utf8_locale=$(locale -a 2>/dev/null | grep -i "^C\.utf" | head -1)
-    if [[ -n "$c_utf8_locale" ]]; then
-      export LANG="$c_utf8_locale"
-      export LC_ALL="$c_utf8_locale"
+# Using anonymous function to keep variables locally scoped
+() {
+  if [[ -z "$LANG" ]] || [[ "$LANG" == "POSIX" ]] || [[ "$LANG" == "C" ]]; then
+    # Capture the actual locale name that exists on the system
+    local utf8_locale=$(locale -a 2>/dev/null | grep -i "^en_US\.utf" | head -1)
+    if [[ -n "$utf8_locale" ]]; then
+      export LANG="$utf8_locale"
+      export LC_CTYPE="$utf8_locale"  # Character classification for width calculations
+    else
+      # Fallback to C.UTF-8 or C.utf8
+      local c_utf8_locale=$(locale -a 2>/dev/null | grep -i "^C\.utf" | head -1)
+      if [[ -n "$c_utf8_locale" ]]; then
+        export LANG="$c_utf8_locale"
+        export LC_CTYPE="$c_utf8_locale"  # Character classification for width calculations
+      fi
     fi
   fi
-fi
+}
 
 if command -v nvim >/dev/null 2>&1; then
   export EDITOR="nvim"

--- a/.dotfiles/shell/zshrc.base
+++ b/.dotfiles/shell/zshrc.base
@@ -9,12 +9,18 @@ SAVEHIST=10000
 # Set UTF-8 locale to properly handle Unicode characters (especially powerline glyphs)
 # This fixes cursor positioning issues with ambiguous-width characters in SSH sessions
 if [[ -z "$LANG" ]] || [[ "$LANG" == "POSIX" ]] || [[ "$LANG" == "C" ]]; then
-  if locale -a 2>/dev/null | grep -qi "en_US.utf8\|en_US.UTF-8"; then
-    export LANG="en_US.UTF-8"
-    export LC_ALL="en_US.UTF-8"
-  elif locale -a 2>/dev/null | grep -qi "C.utf8\|C.UTF-8"; then
-    export LANG="C.UTF-8"
-    export LC_ALL="C.UTF-8"
+  # Capture the actual locale name that exists on the system
+  local utf8_locale=$(locale -a 2>/dev/null | grep -i "^en_US\.utf" | head -1)
+  if [[ -n "$utf8_locale" ]]; then
+    export LANG="$utf8_locale"
+    export LC_ALL="$utf8_locale"
+  else
+    # Fallback to C.UTF-8 or C.utf8
+    local c_utf8_locale=$(locale -a 2>/dev/null | grep -i "^C\.utf" | head -1)
+    if [[ -n "$c_utf8_locale" ]]; then
+      export LANG="$c_utf8_locale"
+      export LC_ALL="$c_utf8_locale"
+    fi
   fi
 fi
 


### PR DESCRIPTION
This pull request adds logic to the `.zshrc.base` configuration to ensure the shell uses a UTF-8 locale by default. This helps properly handle Unicode characters, such as powerline glyphs, and fixes cursor positioning issues with ambiguous-width characters, particularly in SSH sessions.

Locale configuration improvements:

* Added a check to set `LANG` and `LC_ALL` to a UTF-8 locale (`en_US.UTF-8` or `C.UTF-8`) if the current locale is unset, `POSIX`, or `C`, improving Unicode character support in the terminal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable Ghostty SSH shell integration and add UTF-8 locale initialization in zsh when LANG is unset or legacy.
> 
> - **Shell/Terminal Configuration**:
>   - **Ghostty**: Enable SSH shell integration via `shell-integration-features = ssh-env,ssh-terminfo` in `.config/ghostty/config` (with notes on TERM handling and terminfo install).
>   - **zsh**: Add scoped init block in `.dotfiles/shell/zshrc.base` to set `LANG` and `LC_CTYPE` to an available UTF-8 locale (`en_US.UTF-8` or `C.UTF-8`) when current locale is unset/`POSIX`/`C`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f61b9dd735e912b286729e2247645beb0ef4fafc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->